### PR TITLE
Truncate comparisons to ms precision

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,7 +9,7 @@ pub trait Timestamped {
     fn timestamp(&self) -> Timestamp;
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, Debug)]
 pub struct Timestamp { pub secs: u64, pub nsecs: u64 }
 
 #[allow(non_snake_case)]
@@ -54,6 +54,15 @@ impl PartialEq<i64> for Timestamp {
 impl PartialOrd<u64> for Timestamp {
     fn partial_cmp(&self, other: &u64) -> Option<cmp::Ordering> {
         self.to_ms().partial_cmp(other)
+    }
+}
+
+impl PartialOrd<Timestamp> for Timestamp {
+    fn partial_cmp(&self, other: &Timestamp) -> Option<cmp::Ordering> {
+        match self.secs.partial_cmp(&other.secs) {
+            Some(cmp::Ordering::Equal) => self.nsecs.partial_cmp(&other.nsecs),
+            otherwise => otherwise,
+        }
     }
 }
 


### PR DESCRIPTION
This is the alternative fix to #13 that I noted in [a comment there](https://github.com/pnkfelix/tango/issues/13#issuecomment-326944526)

I didn't intend to spend this much time on this when I started, but I definitely have now found some places where:
 *  tango itself was weak (e.g. feedback during its runs); I tried to address some of those with `println!` statements
 * Rust's library ecosystem is weak (e.g. no easy way to format `FileTime` to the human readable ISO format, from what I could see; so I hacked up my own).