### PR TITLE
[WIP] Add alternative entry point to emit rerun-if-changed directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ impl Mtime for MdPath {
 pub fn process_root_with_config(config: Config) -> Result<()> {
     let _root = try!(env::current_dir());
     //println!("Tango is running from: {:?}", root);
-    env::set_current_dir(root).unwrap();
+    env::set_current_dir(_root).unwrap();
 
     let emit_rerun_if = config.rerun_if;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,21 @@ impl Mtime for MdPath {
         }
     }
 }
+
+pub fn process_root_and_emit_rerun() -> Result<()> {
+    // write rerun-if-changed to output file
+    // currently this is a hack using cargo menifest links env var
+    let path = env::var("CARGO_MANIFEST_LINKS").unwrap();
+
+    for entry in WalkDir::new(path) {
+        let entry = entry.unwrap();
+        println!("\ncargo:rerun-if-changed={}", entry.path().display());
+    }
+
+    // call process root
+    process_root()
+}
+
 pub fn process_root() -> Result<()> {
     let _root = try!(env::current_dir());
     // println!("Tango is running from: {:?}", _root);
@@ -797,4 +812,3 @@ fn encode_to_url(code: &str) -> String {
 
 #[cfg(test)]
 mod testing;
-


### PR DESCRIPTION
This introduces a second entry point as described in issue #12.  

The new function (`process_root_and_emit_rerun`) writes a `cargo:rerun-if-changed=PATH` directive for each file tango manages or interacts with in a calling crate.  These lines are written to the build script output file of the calling crate, where cargo will read them.  

This makes sure that if any of the files tango is interested in change, the calling crate will be rebuilt.